### PR TITLE
chore: skip waiting for update on reload

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
         globPatterns: ["**/*.{js,css,html,svg,png,ico}"],
         cleanupOutdatedCaches: true,
         clientsClaim: true,
+        skipWaiting: true,
       },
 
       devOptions: {


### PR DESCRIPTION
Explicitly setting `skipWaiting: true` in `vite.config.ts` should ensure the new service worker activates promptly without waiting.